### PR TITLE
V1.7.7-V1.9.0 OP Stack Fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,10 @@ CELESTIA_MODE=false
 # If not set, default to the official optimism implementation
 
 OPTIMISM_REPO_URL=https://github.com/ethereum-optimism/optimism.git
-OPTIMISM_BRANCH_OR_COMMIT=v1.8.0
+OPTIMISM_BRANCH_OR_COMMIT=v1.9.0
 
 OP_GETH_REPO_URL=https://github.com/ethereum-optimism/op-geth.git
-OP_GETH_BRANCH_OR_COMMIT=v1.101315.2
+OP_GETH_BRANCH_OR_COMMIT=v1.101315.3
 
 ##################################################
 #                 Accounts Info                  #
@@ -65,9 +65,6 @@ L1_BLOCK_TIME=12
 L2_CHAIN_ID=42069
 
 L2_BLOCK_TIME=2
-
-# Name for the deploy config file (Default to getting-started)
-DEPLOYMENT_CONTEXT=getting-started
 
 ##################################################
 #              celestia-da Configuration         #

--- a/entrypoints/op-proposer.sh
+++ b/entrypoints/op-proposer.sh
@@ -13,12 +13,12 @@ fi
 # Check if OP_PROPOSER_L2OO_ADDRESS environment variable is set
 if [ -z "$OP_PROPOSER_L2OO_ADDRESS" ]; then
   # If not set, check if the file exists
-  if [ ! -f "$DEPLOYMENT_DIR/.deploy" ]; then
-    echo "File $DEPLOYMENT_DIR/.deploy does not exist. Please import data/deployments or set the OP_PROPOSER_L2OO_ADDRESS variable."
+  if [ ! -f "$DEPLOYMENT_DIR/artifact.json" ]; then
+    echo "File $DEPLOYMENT_DIR/artifact.json does not exist. Please import data/deployments or set the OP_PROPOSER_L2OO_ADDRESS variable."
     exit 1
   fi
   # Use the address from the $DEPLOYMENT_DIR
-  OP_PROPOSER_L2OO_ADDRESS=$(jq -r .L2OutputOracleProxy $DEPLOYMENT_DIR/.deploy)
+  OP_PROPOSER_L2OO_ADDRESS=$(jq -r .L2OutputOracleProxy $DEPLOYMENT_DIR/artifact.json)
 fi
 
 exec "$BIN_DIR"/op-proposer

--- a/run
+++ b/run
@@ -1,5 +1,31 @@
 #!/bin/bash
 
+# Define colors
+ORANGE='\e[0;33m'
+BLUE='\e[0;34m'
+RED='\e[0;31m'
+GREEN='\e[0;32m'
+NC='\e[0m'
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    echo -e "${RED}Error${NC}: .env file not found."
+    echo -ne "${ORANGE}Do you want to use .env.example and rename it to .env? (yes/no): ${NC}"
+    read -r rename_confirm
+    if [[ "$rename_confirm" =~ ^(yes|y)$ ]]; then
+      mv .env.example .env
+      echo -e "${GREEN}.env.example has been renamed to .env.${NC}"
+    else
+      echo "Exiting."
+      exit 1
+    fi
+  else
+    echo -e "${RED}Error${NC}: .env and .env.example files not found. Exiting."
+    exit 1
+  fi
+fi
+
 # Load environment variables from .env file
 # shellcheck disable=SC1091
 source .env
@@ -10,11 +36,6 @@ command="docker compose"
 # Add profiles based on SEQUENCER_MODE and Celestia support
 [ "$SEQUENCER_MODE" = "true" ] && command+=" --profile sequencer"
 [ "$CELESTIA_MODE" = "true" ] && command+=" --profile celestia"
-
-# Define colors
-ORANGE='\e[0;33m'
-BLUE='\e[0;34m'
-NC='\e[0m'
 
 if [ "$SKIP_DEPLOYMENT_CHECK" = "true" ]; then
   echo -e "${ORANGE}NOTE${NC}: Only genesis.json and rollup.json will be checked (SKIP_DEPLOYMENT_CHECK=$SKIP_DEPLOYMENT_CHECK)."

--- a/scripts/clone-repos.sh
+++ b/scripts/clone-repos.sh
@@ -67,9 +67,9 @@ clone_repo() {
 
 # Use environment variables if set, otherwise default to the official repositories
 OPTIMISM_REPO=${OPTIMISM_REPO_URL:-https://github.com/ethereum-optimism/optimism.git}
-OPTIMISM_BRANCH_OR_COMMIT=${OPTIMISM_BRANCH_OR_COMMIT:-op-node/v1.3.0}
+OPTIMISM_BRANCH_OR_COMMIT=${OPTIMISM_BRANCH_OR_COMMIT:-v1.9.0}
 OP_GETH_REPO=${OP_GETH_REPO_URL:-https://github.com/ethereum-optimism/op-geth.git}
-OP_GETH_BRANCH_OR_COMMIT=${OP_GETH_BRANCH_OR_COMMIT:-v1.101304.2}
+OP_GETH_BRANCH_OR_COMMIT=${OP_GETH_BRANCH_OR_COMMIT:-v1.101315.3}
 
 # Cloning repositories
 clone_repo "$OPTIMISM_REPO" "$OPTIMISM_BRANCH_OR_COMMIT" "$OPTIMISM_DIR" || exit 1

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -122,7 +122,7 @@ export DEPLOY_CONFIG_PATH=./deploy-config/internal-opstack-compose.json # "$CONF
 
 # If not deployed
 if [ ! -f /app/data/deployments/artifact.json ]; then
-  # Determine the script path (fix for v1.7.6)
+  # Determine the script path (fix for v1.7.7)
   DEPLOY_SCRIPT_PATH=$(test -f scripts/deploy/Deploy.s.sol && echo "scripts/deploy/Deploy.s.sol" || echo "scripts/Deploy.s.sol")
 
   # Deploy the L1 contracts

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -122,8 +122,11 @@ export DEPLOY_CONFIG_PATH=./deploy-config/internal-opstack-compose.json # "$CONF
 
 # If not deployed
 if [ ! -f /app/data/deployments/artifact.json ]; then
+  # Determine the script path (fix for v1.7.6)
+  DEPLOY_SCRIPT_PATH=$(test -f scripts/deploy/Deploy.s.sol && echo "scripts/deploy/Deploy.s.sol" || echo "scripts/Deploy.s.sol")
+
   # Deploy the L1 contracts
-  forge script scripts/deploy/Deploy.s.sol:Deploy --private-key "$DEPLOYER_PRIVATE_KEY" --broadcast --rpc-url "$L1_RPC_URL"
+  forge script "$DEPLOY_SCRIPT_PATH" --private-key "$DEPLOYER_PRIVATE_KEY" --broadcast --rpc-url "$L1_RPC_URL"
 
   # Copy the deployment files to the data volume
   cp $DEPLOYMENT_OUTFILE /app/data/deployments/

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -30,9 +30,9 @@ fi
 # Create jwt.txt if it does not exist
 [ -f "$CONFIG_PATH/jwt.txt" ] || openssl rand -hex 32 > "$CONFIG_PATH"/jwt.txt
 
-# Check if all required genesis files exist
+# Check if all required config files exist
 if [ -f "$CONFIG_PATH/genesis.json" ] && [ -f "$CONFIG_PATH/rollup.json" ]; then
-  echo "L2 genesis files are present, skipping prepare.sh script."
+  echo "L2 config files are present, skipping prepare.sh script."
   exec "$@"
   exit 0
 elif [ -f "$CONFIG_PATH/genesis.json" ] || [ -f "$CONFIG_PATH/rollup.json" ]; then
@@ -40,8 +40,8 @@ elif [ -f "$CONFIG_PATH/genesis.json" ] || [ -f "$CONFIG_PATH/rollup.json" ]; th
   exit 1
 fi
 
-# If no genesis files exist, continue with the script
-echo "No required genesis files are present, continuing script execution."
+# If no L2 config files exist, continue with the script
+echo "No required L2 config files are present, continuing script execution."
 
 # Check if all or none of the private keys are provided
 if [ -z "$BATCHER_PRIVATE_KEY" ] && [ -z "$PROPOSER_PRIVATE_KEY" ] && [ -z "$SEQUENCER_PRIVATE_KEY" ]; then
@@ -130,6 +130,7 @@ if [ ! -f /app/data/deployments/artifact.json ]; then
   cp $DEPLOY_CONFIG_PATH "$CONFIG_PATH"/deploy-config.json
 fi
 
+# Generating L2 Allocs
 export CONTRACT_ADDRESSES_PATH=/app/data/deployments/artifact.json
 export STATE_DUMP_PATH=/app/data/deployments/allocs.json
 forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id $L2_CHAIN_ID  --sig 'runWithAllUpgrades()' --private-key $DEPLOYER_PRIVATE_KEY # OR runWithStateDump()

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -60,20 +60,6 @@ else
   exit 1
 fi
 
-# Check if both L1_BLOCKHASH and L1_TIMESTAMP are set or unset
-if [ -n "$L1_BLOCKHASH" ] && [ -z "$L1_TIMESTAMP" ] || [ -z "$L1_BLOCKHASH" ] && [ -n "$L1_TIMESTAMP" ]; then
-  echo "Error: Both L1_BLOCKHASH and L1_TIMESTAMP must be set or unset."
-  exit 1
-elif [ -z "$L1_BLOCKHASH" ] && [ -z "$L1_TIMESTAMP" ]; then
-  # Fetch block details if both variables are unset
-  echo "Fetching block details from L1_RPC_URL..."
-  block=$(cast block finalized --rpc-url "$L1_RPC_URL")
-  L1_TIMESTAMP=$(echo "$block" | awk '/timestamp/ { print $2 }')
-  export L1_TIMESTAMP
-  L1_BLOCKHASH=$(echo "$block" | awk '/hash/ { print $2 }')
-  export L1_BLOCKHASH
-fi
-
 L1_CHAIN_ID=$(cast chain-id --rpc-url "$L1_RPC_URL")
 export L1_CHAIN_ID
 

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -30,18 +30,18 @@ fi
 # Create jwt.txt if it does not exist
 [ -f "$CONFIG_PATH/jwt.txt" ] || openssl rand -hex 32 > "$CONFIG_PATH"/jwt.txt
 
-# Check if all required config files exist
+# Check if all required genesis files exist
 if [ -f "$CONFIG_PATH/genesis.json" ] && [ -f "$CONFIG_PATH/rollup.json" ]; then
-  echo "L2 config files are present, skipping script."
+  echo "L2 genesis files are present, skipping prepare.sh script."
   exec "$@"
   exit 0
 elif [ -f "$CONFIG_PATH/genesis.json" ] || [ -f "$CONFIG_PATH/rollup.json" ]; then
-  echo "Error: Partial L2 config files are present, but not all. Exiting script."
+  echo "Error: One of the genesis.json or rollup.json files is missing."
   exit 1
 fi
 
-# If no components exist, continue with the script
-echo "No required components are present, continuing script execution."
+# If no genesis files exist, continue with the script
+echo "No required genesis files are present, continuing script execution."
 
 # Check if all or none of the private keys are provided
 if [ -z "$BATCHER_PRIVATE_KEY" ] && [ -z "$PROPOSER_PRIVATE_KEY" ] && [ -z "$SEQUENCER_PRIVATE_KEY" ]; then

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -136,7 +136,12 @@ fi
 # Generating L2 Allocs
 export CONTRACT_ADDRESSES_PATH=$DEPLOYMENT_DIR/artifact.json
 export STATE_DUMP_PATH=$DEPLOYMENT_DIR/allocs.json
-forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id "$L2_CHAIN_ID"  --sig 'runWithAllUpgrades()' --private-key "$DEPLOYER_PRIVATE_KEY" # OR runWithStateDump()
+
+if [ -f "$STATE_DUMP_PATH" ]; then
+  echo "State dump already exists, skipping state dump generation."
+else
+  forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id "$L2_CHAIN_ID"  --sig 'runWithAllUpgrades()' --private-key "$DEPLOYER_PRIVATE_KEY" # OR runWithStateDump()
+fi
 
 export DEPLOY_CONFIG_PATH="$CONFIG_PATH"/deploy-config.json
 # Generate the L2 genesis files

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -133,7 +133,7 @@ fi
 # Generating L2 Allocs
 export CONTRACT_ADDRESSES_PATH=/app/data/deployments/artifact.json
 export STATE_DUMP_PATH=/app/data/deployments/allocs.json
-forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id $L2_CHAIN_ID  --sig 'runWithAllUpgrades()' --private-key $DEPLOYER_PRIVATE_KEY # OR runWithStateDump()
+forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id "$L2_CHAIN_ID"  --sig 'runWithAllUpgrades()' --private-key "$DEPLOYER_PRIVATE_KEY" # OR runWithStateDump()
 
 export DEPLOY_CONFIG_PATH="$CONFIG_PATH"/deploy-config.json
 # Generate the L2 genesis files

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -116,11 +116,12 @@ if [ -z "$IMPL_SALT" ]; then
   export IMPL_SALT
 fi
 
+# NOTE: The $DEPLOYMENT_OUTFILE and $DEPLOY_CONFIG_PATH vars are required for line 136
+export DEPLOYMENT_OUTFILE=./deployments/artifact.json
+export DEPLOY_CONFIG_PATH=./deploy-config/internal-opstack-compose.json # "$CONFIG_PATH"/deploy-config.json not suitable due to the error "... not allowed to be accessed for read operations"
+
 # If not deployed
 if [ ! -f /app/data/deployments/artifact.json ]; then
-  export DEPLOYMENT_OUTFILE=./deployments/artifact.json
-  export DEPLOY_CONFIG_PATH=./deploy-config/internal-opstack-compose.json
-
   # Deploy the L1 contracts
   forge script scripts/deploy/Deploy.s.sol:Deploy --private-key "$DEPLOYER_PRIVATE_KEY" --broadcast --rpc-url "$L1_RPC_URL"
 
@@ -130,10 +131,10 @@ if [ ! -f /app/data/deployments/artifact.json ]; then
 fi
 
 export CONTRACT_ADDRESSES_PATH=/app/data/deployments/artifact.json
-export DEPLOY_CONFIG_PATH="$CONFIG_PATH"/deploy-config.json
 export STATE_DUMP_PATH=/app/data/deployments/allocs.json
 forge script scripts/L2Genesis.s.sol:L2Genesis --chain-id $L2_CHAIN_ID  --sig 'runWithAllUpgrades()' --private-key $DEPLOYER_PRIVATE_KEY # OR runWithStateDump()
 
+export DEPLOY_CONFIG_PATH="$CONFIG_PATH"/deploy-config.json
 # Generate the L2 genesis files
 cd "$OPTIMISM_DIR"/op-node
 go run cmd/main.go genesis l2 \


### PR DESCRIPTION
Deployment successfully tested on the latest three versions: v1.7.7, v1.8.0 and v1.9.0 (base sepolia).

Some explanations:
- Setting `$L1_BLOCKHASH` and `$L1_TIMESTAMP` is not required as they are set in the config.sh script.
- `$DEPLOYMENT_CONTEXT` is no longer used in recent versions of op-contracts/* (starting from optimism v1.7.6), so checking `./deploy-config/$DEPLOYMENT_CONTEXT.json` is redundant.
- Also, since v1.7.6, `$chainId-deploy.json` is used instead of `.deploy` for the deployment artifact.
- Fixed the issue where "[Revert] the path /app/data/configurations/deploy-config.json is not allowed to be accessed for read operations" occurred when generating L2 allocs.
